### PR TITLE
Update TurnBasedMatch.cs

### DIFF
--- a/src/highlevel/gamekit7/GameKit/TurnBasedMatch.cs
+++ b/src/highlevel/gamekit7/GameKit/TurnBasedMatch.cs
@@ -173,9 +173,11 @@ namespace U3DXT.iOS.GameKit {
 			get {
 				var participant = gkTurnBasedMatch.currentParticipant;
 //				return NSObjectWrapper.CreateWrapper(typeof(TurnBasedParticipant), participant) as TurnBasedParticipant;
-				foreach (var part in _participants) {
-					if (part.playerID == participant.playerID)
-						return part;
+				if (participant != null) {
+					foreach (var part in _participants) {
+						if (part.playerID == participant.playerID)
+							return part;
+					}
 				}
 				return null;
 			}


### PR DESCRIPTION
Check for currentParticipant being null or else accessing playerID will throw a null exception. The currentParticipant can be null if the match is over.
